### PR TITLE
Add init command to create .repomaterc configuration file

### DIFF
--- a/lib/repomate.rb
+++ b/lib/repomate.rb
@@ -15,6 +15,7 @@ module Repomate
   require_relative 'repomate/infra/persistence/repository_store'
   require_relative 'repomate/application/commands/base'
   require_relative 'repomate/application/commands/add'
+  require_relative 'repomate/application/commands/init'
   require_relative 'repomate/application/commands/list'
   require_relative 'repomate/application/commands/remove'
   require_relative 'repomate/application/commands/sync'

--- a/lib/repomate/application/command_factory.rb
+++ b/lib/repomate/application/command_factory.rb
@@ -11,7 +11,8 @@ module Repomate
         sync: Commands::Sync,
         add: Commands::Add,
         remove: Commands::Remove,
-        list: Commands::List
+        list: Commands::List,
+        init: Commands::Init
       }.freeze
 
       def self.create(name:, config:, store:)

--- a/lib/repomate/application/commands/init.rb
+++ b/lib/repomate/application/commands/init.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Repomate
+  module Application
+    module Commands
+      # Initializes a new .repomaterc configuration file
+      class Init < Base
+        def execute
+          config_path = File.join(Dir.pwd, '.repomaterc')
+          
+          if File.exist?(config_path)
+            puts "Error: .repomaterc already exists in current directory"
+            return
+          end
+
+          # Get existing repositories from the store
+          repositories = store.all.map(&:url)
+          
+          # Create the configuration structure
+          config_data = {
+            repositories: repositories,
+            repos_root_path: config.code_path
+          }
+
+          # Write the configuration file
+          File.write(config_path, JSON.pretty_generate(config_data))
+          
+          puts "✅ Created .repomaterc with #{repositories.length} repositories"
+          puts "📁 Root path set to: #{config.code_path}"
+        rescue StandardError => e
+          puts "Error creating .repomaterc: #{e.message}"
+        end
+      end
+    end
+  end
+end

--- a/lib/repomate/config/configuration.rb
+++ b/lib/repomate/config/configuration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'optparse'
+require 'json'
 
 module Repomate
   module Config
@@ -15,11 +16,44 @@ module Repomate
         @config_file_path = "#{home_path}/code/.subscribed-repos"
         @command = ARGV[0] || 'sync'
 
+        # Check for .repomaterc in current directory first
+        load_repomaterc_if_exists!
+        
         parse_options!
         ensure_directories!
       end
 
       private
+
+      def load_repomaterc_if_exists!
+        repomaterc_path = File.join(Dir.pwd, '.repomaterc')
+        return unless File.exist?(repomaterc_path)
+
+        begin
+          config_data = JSON.parse(File.read(repomaterc_path))
+          
+          # Update code_path from repos_root_path if present
+          @code_path = config_data['repos_root_path'] if config_data['repos_root_path']
+          
+          # Create a temporary config file with repositories if it has them
+          if config_data['repositories'] && !config_data['repositories'].empty?
+            temp_config_dir = File.join(@code_path, '.repomate')
+            FileUtils.mkdir_p(temp_config_dir)
+            @config_file_path = File.join(temp_config_dir, '.subscribed-repos')
+            
+            # Write repositories to the config file
+            File.write(@config_file_path, config_data['repositories'].join("\n") + "\n")
+          end
+          
+          puts "📋 Loaded configuration from .repomaterc"
+        rescue JSON::ParserError => e
+          puts "Warning: Invalid JSON in .repomaterc: #{e.message}"
+          puts "Falling back to default configuration"
+        rescue StandardError => e
+          puts "Warning: Error reading .repomaterc: #{e.message}"
+          puts "Falling back to default configuration"
+        end
+      end
 
       def parse_options!
         OptionParser.new do |opts|


### PR DESCRIPTION
## Overview

This PR adds a new `init` command that creates a `.repomaterc` configuration file in the current directory.

## Features

### New `init` Command
- Creates a `.repomaterc` file with current repository configuration
- Includes all subscribed repositories from the existing configuration
- Sets the `repos_root_path` to the current code path
- Prevents overwriting existing `.repomaterc` files

### Enhanced Configuration Loading
- Automatically detects and loads `.repomaterc` files in the current directory
- Falls back to existing behavior when no `.repomaterc` is present
- Supports JSON configuration format with proper error handling

## Configuration File Format

The `.repomaterc` file contains:
```json
{
  "repositories": [
    "git@github.com:user/repo1.git",
    "git@github.com:user/repo2.git"
  ],
  "repos_root_path": "/path/to/code"
}
```

## Changes Made

- **New file**: `lib/repomate/application/commands/init.rb` - Implementation of the init command
- **Modified**: `lib/repomate/application/command_factory.rb` - Added init command to factory
- **Modified**: `lib/repomate/config/configuration.rb` - Added .repomaterc loading support
- **Modified**: `lib/repomate.rb` - Added require for init command

## Testing

- ✅ `init` command creates proper `.repomaterc` file
- ✅ Configuration loads from `.repomaterc` when present
- ✅ Falls back to original behavior when no `.repomaterc` exists
- ✅ Error handling for existing `.repomaterc` files
- ✅ Help command shows new `init` command